### PR TITLE
Fix undefined error when trying to calculate review stats

### DIFF
--- a/lib/useEndpoint.js
+++ b/lib/useEndpoint.js
@@ -129,7 +129,7 @@ const formatData = (endpoint, newData) => {
   if (endpoint === 'subjects') {
     return newData.map(({ id, object, data }) => ({
       id: id,
-      type: object,
+      type: mergeKanaAndKanjiVocabTypes(object),
       level: data.level,
       char: data.characters,
     }));
@@ -145,7 +145,7 @@ const formatData = (endpoint, newData) => {
   if (endpoint === 'assignments') {
     return newData.map(({ data }) => ({
       id: data.subject_id,
-      type: data.subject_type,
+      type: mergeKanaAndKanjiVocabTypes(data.subject_type),
       stage: data.srs_stage,
     }));
   }
@@ -154,13 +154,17 @@ const formatData = (endpoint, newData) => {
     // prettier-ignore
     return newData.map(({ data }) => ({
       id: data.subject_id,
-      type: data.subject_type,
+      type: mergeKanaAndKanjiVocabTypes(data.subject_type),
       mc: data.meaning_correct,
       mi: data.meaning_incorrect,
       rc: data.reading_correct,
       ri: data.reading_incorrect,
     }));
   }
+};
+
+const mergeKanaAndKanjiVocabTypes = (subjectType) => {
+  return subjectType === 'kana_vocabulary' ? 'vocabulary' : subjectType;
 };
 
 const mergeData = (endpoint, a, b) => {

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -65,6 +65,7 @@ const Dashboard = () => {
     radical: { mc: 0, mi: 0, rc: 0, ri: 0 },
     kanji: { mc: 0, mi: 0, rc: 0, ri: 0 },
     vocabulary: { mc: 0, mi: 0, rc: 0, ri: 0 },
+    kana_vocabulary: { mc: 0, mi: 0, rc: 0, ri: 0 },
   };
   let accuracy = reviewStats.reduce((a, c) => {
     a[c.type].mc += c.mc;

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -65,7 +65,6 @@ const Dashboard = () => {
     radical: { mc: 0, mi: 0, rc: 0, ri: 0 },
     kanji: { mc: 0, mi: 0, rc: 0, ri: 0 },
     vocabulary: { mc: 0, mi: 0, rc: 0, ri: 0 },
-    kana_vocabulary: { mc: 0, mi: 0, rc: 0, ri: 0 },
   };
   let accuracy = reviewStats.reduce((a, c) => {
     a[c.type].mc += c.mc;


### PR DESCRIPTION
This should fix the error reported in wk forum https://community.wanikani.com/t/statkani-data-visualizations-for-wanikani/53929/83:
```
TypeError: Cannot read properties of undefined (reading ‘mc’)
at dashboard-ca154bcdaa3a0de2bb01.js:1:14203
at Array.reduce ()
at ye (dashboard-ca154bcdaa3a0de2bb01.js:1:14173)
at ro (framework-2191d16384373197bc0a.js:1:60216)
at jo (framework-2191d16384373197bc0a.js:1:69783)
at Hu (framework-2191d16384373197bc0a.js:1:113665)
at Pi (framework-2191d16384373197bc0a.js:1:99848)
at xi (framework-2191d16384373197bc0a.js:1:99776)
at _i (framework-2191d16384373197bc0a.js:1:99639)
at vi (framework-2191d16384373197bc0a.js:1:96605)
uu @ framework-2191d16384373197bc0a.js:1
main-d7431fe8ee9bc358dd07.js:1 TypeError: Cannot read properties of undefined (reading ‘mc’)
at dashboard-ca154bcdaa3a0de2bb01.js:1:14203
at Array.reduce ()
at ye (dashboard-ca154bcdaa3a0de2bb01.js:1:14173)
at ro (framework-2191d16384373197bc0a.js:1:60216)
at jo (framework-2191d16384373197bc0a.js:1:69783)
at Hu (framework-2191d16384373197bc0a.js:1:113665)
at Pi (framework-2191d16384373197bc0a.js:1:99848)
at xi (framework-2191d16384373197bc0a.js:1:99776)
at _i (framework-2191d16384373197bc0a.js:1:99639)
at vi (framework-2191d16384373197bc0a.js:1:96605)
le @ main-d7431fe8ee9bc358dd07.js:1
```

Tried it locally and it works now. The issue was that there seems to be a new review stat type `kana_vocabulary` which I've now just added to the initial state for the reduce. 